### PR TITLE
Build best practices

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ############################
 # Build container
 ############################
-FROM node:10-alpine AS dep
+FROM node:12-alpine AS dep
 
 WORKDIR /ops
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,9 +19,10 @@ WORKDIR /ops
 
 ENV AWS_CLI_VERSION=1.18.52
 RUN apt-get update \
-        && apt-get install -y make curl wget unzip ca-certificates openssh-client python-pip \
+        && apt-get install -y --no-install-recommends make curl wget unzip ca-certificates openssh-client python-pip python-setuptools python-wheel \
         && pip install --no-cache-dir awscli==${AWS_CLI_VERSION} \
-        && apt-get purge -y python-pip \
+        && apt-get purge -y python-pip python-setuptools \
+        && apt-get autoremove -y \
         && apt-get clean \
         && rm -rf /var/lib/apt/lists
 

--- a/ops.yml
+++ b/ops.yml
@@ -13,7 +13,7 @@ commands:
       - package.json
       - .dockerignore
     mountCwd: false
-    mountHome: ffalse
+    mountHome: false
     help:
       usage: |-
         This Op requires AWS credentials. Please review the Op readme for details on how to generate and set up these credentials as secrets.


### PR DESCRIPTION
Apply the build best practices to the EKS op. This should improve build speed and also cuts the final image size by roughly 300 MB.